### PR TITLE
#154239872 Add a side bar for deactivated users in the gym

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -65,3 +65,5 @@ venv-django/
 # External Libraries 
 wger/core/static/bower_components
 node_modules
+venv-django
+package-lock.json

--- a/wger/core/templates/user/list.html
+++ b/wger/core/templates/user/list.html
@@ -1,14 +1,16 @@
 {% extends "base.html" %}
 {% load i18n staticfiles wger_extras django_bootstrap_breadcrumbs %}
 
-{% block title %}{% trans "User list" %}{% endblock %}
+{% block title %}
+{% trans "User list" %}
+{% endblock %}
 
 
 {% block content %}
     {% include 'gym/partial_user_list.html' %}
 {% endblock %}
 
-
 {% block sidebar %}
-
+    <h4>Inactive users</h4>
+    {% include 'gym/partial_Inactiveuser_list.html' %}
 {% endblock %}

--- a/wger/gym/templates/gym/partial_Inactiveuser_list.html
+++ b/wger/gym/templates/gym/partial_Inactiveuser_list.html
@@ -1,0 +1,27 @@
+{% load i18n staticfiles %}
+
+<link rel="stylesheet" type="text/css" href="{% static 'bower_components/datatables/media/css/dataTables.bootstrap.min.css' %}">
+<script src="{% static 'bower_components/datatables/media/js/jquery.dataTables.min.js' %}" ></script>
+<script src="{% static 'bower_components/datatables/media/js/dataTables.bootstrap.min.js' %}" ></script>
+
+<table class="table table-hover table-condensed">
+<thead>
+</thead>
+<tbody>
+{% for current_user in user_table.users %}
+  {% if not current_user.obj.is_active %}
+    <tr>
+        <td>
+            <a href="{% url 'core:user:overview' current_user.obj.pk %}">{{current_user.obj}}</a>
+        </td>
+        <td>
+            {{current_user.obj.get_full_name}}
+        </td>
+        <td>
+            <a class="btn btn-success btn-xs" href="{% url 'core:user:activate' current_user.obj.pk %}">Activate</a>
+        </td>
+    </tr>
+  {% endif %}
+{% endfor %}
+</tbody>
+</table>

--- a/wger/gym/templates/gym/partial_user_list.html
+++ b/wger/gym/templates/gym/partial_user_list.html
@@ -24,31 +24,33 @@ $(document).ready( function () {
 </thead>
 <tbody>
 {% for current_user in user_table.users %}
-<tr>
-    <td>
-        {{current_user.obj.pk}}
-    </td>
-    <td>
-        <a href="{% url 'core:user:overview' current_user.obj.pk %}">{{current_user.obj}}</a>
-    </td>
-    <td>
-        {{current_user.obj.get_full_name}}
-    </td>
-    <td data-order="{{current_user.last_log|date:'U'}}">
-        {{current_user.last_log|default:'-/-'}}
-    </td>
-    {% if show_gym %}
-    <td>
-        {% if current_user.obj.userprofile.gym_id %}
-            <a href="{{ current_user.obj.userprofile.gym.get_absolute_url }}">
-            {{ current_user.obj.userprofile.gym }}
-            </a>
-        {% else %}
-            -/-
+    {% if current_user.obj.is_active %}
+    <tr>
+        <td>
+            {{current_user.obj.pk}}
+        </td>
+        <td>
+            <a href="{% url 'core:user:overview' current_user.obj.pk %}">{{current_user.obj}}</a>
+        </td>
+        <td>
+            {{current_user.obj.get_full_name}}
+        </td>
+        <td data-order="{{current_user.last_log|date:'U'}}">
+            {{current_user.last_log|default:'-/-'}}
+        </td>
+        {% if show_gym %}
+        <td>
+            {% if current_user.obj.userprofile.gym_id %}
+                <a href="{{ current_user.obj.userprofile.gym.get_absolute_url }}">
+                {{ current_user.obj.userprofile.gym }}
+                </a>
+            {% else %}
+                -/-
+            {% endif %}
+        </td>
         {% endif %}
-    </td>
+    </tr>
     {% endif %}
-</tr>
 {% endfor %}
 </tbody>
 </table>


### PR DESCRIPTION
#### What does this PR do?
Add a side bar for deactivated users in the gym

#### Description of Task to be completed?
 At the moment, the only way to determine whether a gym member is active or not is to open his detail view. A better alternative would be to list only active members in the default list and have a second overview page for the deactivated ones.

#### What are the relevant pivotal tracker stories?
[#154239872](https://www.pivotaltracker.com/story/show/154239872)

#### Screenshots (if appropriate)
<img width="1176" alt="screen shot 2018-01-17 at 1 53 05 pm" src="https://user-images.githubusercontent.com/22788274/35039100-ec3aa412-fb8d-11e7-888c-33d2d9a6445d.png">
