### PR TITLE
#154239873 Cache nutritional values

### DIFF
--- a/wger/nutrition/__init__.py
+++ b/wger/nutrition/__init__.py
@@ -17,7 +17,6 @@
 
 from wger import get_version
 
-VERSION = get_version()
+VERSION = get_version()s
 
 default_app_config = 'wger.nutrition.apps.NutritionConfig'
-

--- a/wger/nutrition/__init__.py
+++ b/wger/nutrition/__init__.py
@@ -17,6 +17,6 @@
 
 from wger import get_version
 
-VERSION = get_version()s
+VERSION = get_version()
 
 default_app_config = 'wger.nutrition.apps.NutritionConfig'

--- a/wger/nutrition/__init__.py
+++ b/wger/nutrition/__init__.py
@@ -15,7 +15,9 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with Workout Manager.  If not, see <http://www.gnu.org/licenses/>.
 
-
 from wger import get_version
 
 VERSION = get_version()
+
+default_app_config = 'wger.nutrition.apps.NutritionConfig'
+

--- a/wger/nutrition/apps.py
+++ b/wger/nutrition/apps.py
@@ -1,0 +1,33 @@
+# -*- coding: utf-8 -*-
+
+# This file is part of wger Workout Manager.
+#
+# wger Workout Manager is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# wger Workout Manager is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+
+from django.apps import AppConfig
+
+
+class NutritionConfig(AppConfig):
+    """
+    Class representing a nutrition application and its configuration.
+    """
+
+    name = 'wger.nutrition'
+    verbose_name = "Nutrition"
+
+    def ready(self):
+        """
+        Do something when Django starts.
+        """
+
+        import wger.nutrition.signals

--- a/wger/nutrition/signals.py
+++ b/wger/nutrition/signals.py
@@ -50,7 +50,6 @@ def reset_cache(sender, instance, **kwargs):
     if hasattr(instance, 'plan'):
         pid = getattr(instance, 'plan').pk
 
-
     elif hasattr(instance, 'meal'):
         pid = getattr(instance, 'meal').plan.pk
 

--- a/wger/nutrition/signals.py
+++ b/wger/nutrition/signals.py
@@ -1,0 +1,61 @@
+# -*- coding: utf-8 -*-
+
+# This file is part of wger Workout Manager.
+#
+# wger Workout Manager is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# wger Workout Manager is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with Workout Manager.  If not, see <http://www.gnu.org/licenses/>.
+
+"""
+Nutrition app signal module.
+"""
+
+
+from django.core.cache import cache
+from django.db.models.signals import post_delete, post_save
+from django.dispatch import receiver
+
+from wger.utils.cache import cache_mapper
+from .models import NutritionPlan, Meal, MealItem
+
+
+@receiver(post_save, sender=NutritionPlan)
+@receiver(post_save, sender=Meal)
+@receiver(post_save, sender=MealItem)
+@receiver(post_delete, sender=NutritionPlan)
+@receiver(post_delete, sender=Meal)
+@receiver(post_delete, sender=MealItem)
+def reset_cache(sender, instance, **kwargs):
+    """
+    We need to get nutritional plan id.
+
+    Models that have relationship to NutritionalPlan model are:
+        Meal -> plan
+        MealItem -> meal -> plan
+
+    Retrieving NutritionPlan instance is necessary so that we can
+    be able to get object in cache and remove it.
+    """
+    pid = None
+
+    if hasattr(instance, 'plan'):
+        pid = getattr(instance, 'plan').pk
+
+
+    elif hasattr(instance, 'meal'):
+        pid = getattr(instance, 'meal').plan.pk
+
+    else:
+        pid = instance.pk
+
+    # clear object in cache
+    cache.delete(cache_mapper.get_nutritional_key(pid))

--- a/wger/utils/cache.py
+++ b/wger/utils/cache.py
@@ -122,4 +122,5 @@ class CacheKeyMapper(object):
         '''
         return self.WORKOUT_LOG_LIST.format(hash_value)
 
+
 cache_mapper = CacheKeyMapper()

--- a/wger/utils/cache.py
+++ b/wger/utils/cache.py
@@ -65,6 +65,7 @@ class CacheKeyMapper(object):
     LANGUAGE_CONFIG_CACHE_KEY = 'language-config-{0}-{1}'
     EXERCISE_CACHE_KEY_MUSCLE_BG = 'exercise-muscle-bg-{0}'
     INGREDIENT_CACHE_KEY = 'ingredient-{0}'
+    NUTRITIONAL_CACHE_KEY = 'nutrition-{0}'
     WORKOUT_CANONICAL_REPRESENTATION = 'workout-canonical-representation-{0}'
     WORKOUT_LOG_LIST = 'workout-log-hash-{0}'
 
@@ -102,6 +103,12 @@ class CacheKeyMapper(object):
         Return the ingredient cache key
         '''
         return self.INGREDIENT_CACHE_KEY.format(self.get_pk(param))
+
+    def get_nutritional_key(self, param):
+        '''
+        Return the nutritional cache key
+        '''
+        return self.NUTRITIONAL_CACHE_KEY.format(self.get_pk(param))
 
     def get_workout_canonical(self, param):
         '''


### PR DESCRIPTION
#### What does this PR do?
Caches nutritional values so that when viewing nutritional plans the page load time is fast.

#### Description of Task to be completed?
1. Cache the `nutritional_info` dictionary in `NutritionPlan` model.
2. Add `signals` that `delete` the cache key every time a `NutritionPlan`, `Meal` and `MealItem` is **added**, **edited** or **deleted**.

#### How should this be manually tested?
1. On your **terminal/cmd** navigate to a directory named `extras/dummy_generator` then generate **40** and run the command `python3 generator.py nutrition 40` which will generate **40** nutrition plans.

2. Open your browser(*preferably Chrome*) and right click to inspect element then click on **`Network`**.

3.  Navigate to **Nutritional Plans** page. After the page loads for the first time you will notice that the time takes longer and the time it takes is in **seconds** but when you reload the page for the second time it takes less time and the time is in **milliseconds**.

#### What are the relevant pivotal tracker stories?
[#154239873](https://www.pivotaltracker.com/story/show/154239873)

#### Screenshots (if appropriate)
**Initial page load**
<img width="1440" alt="screen shot 2018-01-18 at 09 34 09" src="https://user-images.githubusercontent.com/15877982/35084032-07aaf83c-fc33-11e7-8293-fcde78db1be2.png">

**After page load**
<img width="1440" alt="screen shot 2018-01-18 at 09 34 39" src="https://user-images.githubusercontent.com/15877982/35084047-155a0bee-fc33-11e7-9ddd-b45170e7ebc5.png">

#### Questions:
None