### PR TITLE
#154239881 Allow comparison for members training together.

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -25,6 +25,7 @@
     "tinymce": "tinymce-dist#^4.7.4",
     "jquery": "2.1.x",
     "metrics-graphics": "^2.12.0",
-    "devbridge-autocomplete": "1.2.x"
+    "devbridge-autocomplete": "1.2.x",
+    "chart.js": "^2.7.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "gulp-eslint": "^3.0.1"
   },
   "dependencies": {
-    "bower": "^1.8.2"
+    "bower": "^1.8.2",
+    "chart.js": "^2.7.1"
   }
 }

--- a/wger/core/templates/tags/render_weight_log.html
+++ b/wger/core/templates/tags/render_weight_log.html
@@ -1,5 +1,5 @@
 {% load i18n staticfiles wger_extras %}
-<div id="svg-{{div_uuid}}" style="text-align:center;"></div>
+<canvas id="svg-{{div_uuid}}" style="text-align:center;"></canvas>
 
 <div style="overflow-x: auto;" class="weight-chart-table">
 <table class="noborder" style="border: 0 none; width: 7em;">

--- a/wger/core/templates/template.html
+++ b/wger/core/templates/template.html
@@ -66,6 +66,8 @@
     <script src="{% static 'bower_components/d3/d3.js' %}"></script>
     <script src="{% static 'bower_components/metrics-graphics/dist/metricsgraphics.min.js' %}"></script>
     <script src="{% static 'bower_components/devbridge-autocomplete/dist/jquery.autocomplete.min.js' %}"></script>
+    <script src="{% static 'bower_components/chart.js/dist/Chart.bundle.min.js' %}"></script>
+
     <script src="{% static 'js/wger-core.js' %}"></script>
     <script src="{% static 'js/exercises.js' %}"></script>
     <script src="{% static 'js/nutrition.js' %}"></script>

--- a/wger/exercises/static/js/exercises.js
+++ b/wger/exercises/static/js/exercises.js
@@ -23,6 +23,7 @@
 /*
  Highlight a muscle in the overview
  */
+
 function wgerHighlightMuscle(element) {
   var $muscle;
   var muscleId;
@@ -55,40 +56,96 @@ function wgerHighlightMuscle(element) {
  D3js functions
  */
 
-function wgerDrawWeightLogChart(data, divId) {
-  var chartData;
-  var legend;
-  var minValues;
-  var i;
-  if (data.length) {
-    legend = [];
-    minValues = [];
-    chartData = [];
-    for (i = 0; i < data.length; i++) {
-      chartData[i] = MG.convert.date(data[i], 'date');
+function wgerDrawWeightLogChart(data, otherData, divId, otherUser) {
+  let ctx = document.getElementById('svg-' + divId);
 
-      // Read the possible repetitions for the chart legend
-      legend[i] = data[i][0].reps;
+  // process my data into appropriate fields for the graph
+  let listOfChartData = [];
+  let chartData = {
+    dates: [],
+    weight: [],
+    reps: []
+  };
+  data.forEach((element) => {
+    element.forEach((item)  => {
+      chartData.dates.push(item.date);
+      chartData.weight.push(item.weight);
+      chartData.reps.push(item.reps);
+    });
+  });
+  listOfChartData.push(chartData);
 
-      // Read the minimum values for each repetition
-      minValues[i] = d3.min(data[i], function (repetitionData) {
-        return repetitionData.weight;
+  // process other user's data into required fields for the graph
+  if (otherData) {
+    let listOfOtherData =[];
+    let otherChartData = {
+      dates: [],
+      weight: [],
+      reps: []
+    };
+    otherData.forEach((element) => {
+      element.forEach((item)  => {
+        otherChartData.dates.push(item.date);
+        otherChartData.weight.push(item.weight);
+        otherChartData.reps.push(item.reps);
       });
-    }
+    });
+    listOfOtherData.push(otherChartData);
 
-    MG.data_graphic({
-      data: chartData,
-      y_accessor: 'weight',
-      min_y: d3.min(minValues),
-      aggregate_rollover: true,
-      full_width: true,
-      top: 10,
-      left: 30,
-      right: 10,
-      height: 200,
-      legend: legend,
-      target: '#svg-' + divId,
-      colors: ['#204a87', '#4e9a06', '#ce5c00', '#5c3566', '#2e3436', '8f5902', '#a40000']
+    var myChart = new Chart(ctx, {
+      type: 'bar',
+        data: {
+          labels: listOfChartData[0].dates, // dates for x axis
+          datasets: [{
+            label: "My weights",
+            backgroundColor: '#3465a4',
+            borderColor: '#3465a4',
+            data: listOfChartData[0].weight // to be plotted against the y-axis
+          },
+          {
+            label: "My reps",
+              backgroundColor: '#7093bf',
+              borderColor: '#7093bf',
+              data: listOfChartData[0].reps  // to be plotted against the x-axis
+          },
+          {
+            label: otherUser + "'s weights",
+            backgroundColor: '#900C3F',
+            borderColor: '#900C3F',
+            data: listOfOtherData[0].weight // to be plotted against the y-axis
+          },
+          {
+            label: otherUser + "'s reps",
+              backgroundColor: '#F5B9B9',
+              borderColor: '#7873bf',
+              data: listOfOtherData[0].reps  // to be plotted against the x-axis
+          }]
+        },
+        options: {
+        }
+    });
+
+
+  } else {
+    var myChart = new Chart(ctx, {
+      type: 'bar',
+        data: {
+          labels: listOfChartData[0].dates, // dates for x axis
+          datasets: [{
+            label: "My weights",
+            backgroundColor: '#3465a4',
+            borderColor: '#3465a4',
+            data: listOfChartData[0].weight // to be plotted against the y-axis
+          },
+          {
+            label: "My reps",
+              backgroundColor: '#7093bf',
+              borderColor: '#7093bf',
+              data: listOfChartData[0].reps  // to be plotted against the x-axis
+          }]
+        },
+        options: {
+        }
     });
   }
 }

--- a/wger/manager/templates/workout/log.html
+++ b/wger/manager/templates/workout/log.html
@@ -56,6 +56,25 @@
         </a>
     </p>
     {% endif %}
+    <br />
+
+    <h4>{% trans "Compare with other user" %}</h4>
+    <form class="form-inline" action="{% url 'manager:log:log' workout.id %}" method="get">
+        <select name="search_user"
+            type="search"
+            id="user-search"
+            class="ajax-form-element form-control"
+            style="width: 400px;"
+        >
+            <option value="">Select user</option>
+            {% for profile in user_profiles %}
+                {% if profile.user.id != owner_user.id %}
+                    <option value="{{ profile.user.username }}">{{ profile.user.username }}</option>
+                {% endif %}
+            {% endfor %}
+        </select>
+        <button class="btn btn-success btn-sm" type="submit" style="width: 100px;">Select</button>
+    </form><br/>
 
     {% for set in day.set_list %}
     {% for exercise in set.exercise_list %}
@@ -76,7 +95,8 @@
                             <script>
                             $(document).ready(function() {
                             wgerDrawWeightLogChart({{exercise_list.chart_data|safe}},
-                                                  "{{exercise_list.div_uuid}}");
+                                                    {{ exercise_list.other_chart_data|safe }},
+                                                  "{{exercise_list.div_uuid}}", "{{ other_user}}");
                             });
                             </script>
                         {% endwith %}
@@ -105,6 +125,8 @@
 {# Side bar #}
 {#          #}
 {% block sidebar %}
+
+
 <h4>{% trans "Notes" %}</h4>
 <p>{% blocktrans %}This page shows the weight logs belonging to this workout
 only. Click on an exercise to see all the historical data for

--- a/wger/manager/views/log.py
+++ b/wger/manager/views/log.py
@@ -286,14 +286,13 @@ class WorkoutLogDetailView(DetailView, LoginRequiredMixin):
                         workout=self.object)\
                         .exclude(repetition_unit_id__in=(2, 3, 4, 5, 6, 7, 8))
 
-
                     # get logs for other user and generate chart data from them
                     if other_user:
-                        other_logs = exercise_list['obj'].workoutlog_set.filter(user=other_user,
-                                                                                weight_unit__in=(1, 2),
-                                                                                exercise=exercise_list['obj']
-                                                                                ) \
-                        .exclude(repetition_unit_id__in=(2, 3, 4, 5, 6, 7, 8))
+                        other_logs = exercise_list['obj'].workoutlog_set.filter(
+                            user=other_user,
+                            weight_unit__in=(1, 2),
+                            exercise=exercise_list['obj']) \
+                            .exclude(repetition_unit_id__in=(2, 3, 4, 5, 6, 7, 8))
 
                     if other_logs:
                         entry_log, other_chart_data = process_log_entries(other_logs)

--- a/wger/manager/views/log.py
+++ b/wger/manager/views/log.py
@@ -36,6 +36,11 @@ from wger.manager.forms import (HelperDateForm, HelperWorkoutSessionForm,
 from wger.utils.generic_views import (WgerFormMixin, WgerDeleteMixin)
 from wger.utils.helpers import check_access
 from wger.weight.helpers import process_log_entries, group_log_entries
+<<<<<<< HEAD
+=======
+from wger.core.models import UserProfile
+from wger.manager.models import User
+>>>>>>> [Feature #154239881] Allow user to select another user and extract other user's log
 
 logger = logging.getLogger(__name__)
 
@@ -239,6 +244,16 @@ class WorkoutLogDetailView(DetailView, LoginRequiredMixin):
     owner_user = None
 
     def get_context_data(self, **kwargs):
+        other_logs = None
+
+        # assigned to null, equivalent of python None in js
+        other_chart_data = 'null'
+
+        try:
+            other_username = self.request.GET.get('search_user')
+            other_user = User.objects.get(username=other_username)
+        except:
+            other_user = None
 
         # Call the base implementation first to get a context
         context = super(WorkoutLogDetailView, self).get_context_data(**kwargs)
@@ -270,23 +285,47 @@ class WorkoutLogDetailView(DetailView, LoginRequiredMixin):
                         user=self.owner_user, weight_unit__in=(1, 2),
                         workout=self.object)\
                         .exclude(repetition_unit_id__in=(2, 3, 4, 5, 6, 7, 8))
+
+
+                    # get logs for other user and generate chart data from them
+                    if other_user:
+                        other_logs = exercise_list['obj'].workoutlog_set.filter(user=other_user,
+                                                                                weight_unit__in=(1, 2),
+                                                                                exercise=exercise_list['obj']
+                                                                                ) \
+                        .exclude(repetition_unit_id__in=(2, 3, 4, 5, 6, 7, 8))
+
+                    if other_logs:
+                        entry_log, other_chart_data = process_log_entries(other_logs)
+                    else:
+                        # javascript equivalent of python None
+                        other_chart_data = 'null'
+
                     entry_log, chart_data = process_log_entries(logs)
                     if entry_log:
                         exercise_log[exercise_list['obj'].id].append(entry_log)
 
                     if exercise_log:
                         workout_log[day_id][exercise_id] = {}
-                        workout_log[day_id][exercise_id][
-                            'log_by_date'] = entry_log
-                        workout_log[day_id][exercise_id]['div_uuid'] = 'div-'\
-                            + str(uuid.uuid4())
-                        workout_log[day_id][exercise_id][
-                            'chart_data'] = chart_data
+                        workout_log[day_id][exercise_id]['log_by_date'] = entry_log
+                        workout_log[day_id][exercise_id]['div_uuid'] = 'div-' + str(uuid.uuid4())
+                        workout_log[day_id][exercise_id]['chart_data'] = chart_data
+                        workout_log[day_id][exercise_id]['other_chart_data'] = other_chart_data
 
         context['workout_log'] = workout_log
         context['owner_user'] = self.owner_user
         context['is_owner'] = is_owner
         context['show_shariff'] = is_owner
+
+        # query for users with public profile
+        users = UserProfile.objects.filter(ro_access=True)
+        context['user_profiles'] = users
+
+        # add currently selected user
+        if not other_username:
+            other_username = 'null'
+
+        context['other_user'] = other_username
 
         return context
 

--- a/wger/manager/views/log.py
+++ b/wger/manager/views/log.py
@@ -36,11 +36,8 @@ from wger.manager.forms import (HelperDateForm, HelperWorkoutSessionForm,
 from wger.utils.generic_views import (WgerFormMixin, WgerDeleteMixin)
 from wger.utils.helpers import check_access
 from wger.weight.helpers import process_log_entries, group_log_entries
-<<<<<<< HEAD
-=======
 from wger.core.models import UserProfile
 from wger.manager.models import User
->>>>>>> [Feature #154239881] Allow user to select another user and extract other user's log
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
#### What does this PR do?
Allows members who are training together to compare their workout sessions using their workout logs.

#### Description of the tasks to be completed?
* Allow a user to select another member from a list of users with public profiles.
* Remodel the charts for log overview to allow easy visual comparisons.
* Map both user's data on the same graph.

#### What are the relevant pivotal tracker stories?
[#154239881](https://www.pivotaltracker.com/story/show/154239881)

#### Screenshots
##### Charts before remodel
<img width="583" alt="screen shot 2018-01-25 at 2 51 29 pm" src="https://user-images.githubusercontent.com/9306725/35387087-780e874a-01df-11e8-82a9-e900206aa2dc.png">

##### Charts after remodel without comparison
<img width="840" alt="screen shot 2018-01-25 at 2 45 22 pm" src="https://user-images.githubusercontent.com/9306725/35387125-99a1502c-01df-11e8-8c80-79556d5647e6.png">

##### Charts after remodel with comparison of members
<img width="816" alt="screen shot 2018-01-25 at 12 49 52 pm" src="https://user-images.githubusercontent.com/9306725/35387157-b01dfc92-01df-11e8-94c1-0fc2122527ee.png">
