### PR TITLE
#154239892 Enable viewing of exercises for a body part on hover

### DIFF
--- a/wger/exercises/templates/exercise/overview.html
+++ b/wger/exercises/templates/exercise/overview.html
@@ -28,6 +28,14 @@ $(document).ready(function() {
             window.location.href = '/exercise/' + suggestion.data.id + '/view/'
         }
     });
+    (function ($) {
+        $(function () {
+          $(document).off('click.bs.tab.data-api', '[data-hover="tab"]');
+          $(document).on('mouseenter.bs.tab.data-api', '[data-toggle="tab"], [data-hover="tab"]', function () {
+            $(this).tab('show');
+          });
+        });
+      })(jQuery);
 });
 </script>
 {% endblock %}
@@ -40,7 +48,7 @@ $(document).ready(function() {
 
 {% cache cache_timeout exercise-overview language.id %}
 {% regroup exercises by category as exercise_list %}
-<ul class="nav nav-tabs">
+<ul class="nav nav-pills" style="margin-bottom:20px">
     {% for item in exercise_list %}
     <li {% if forloop.first %}class="active"{% endif %}>
         <a href="#tab-{{ item.grouper.id }}" id="category-{{ item.grouper.id }}" data-toggle="tab">{% trans item.grouper.name %}</a>


### PR DESCRIPTION
#### What does this PR do?
The user should be able to move mouse over a body part and get exercises for that body part.

#### Description of Task to be completed?
When a user hovers over the body part tab, the exercises for that body part are listed.

#### How should this be manually tested?
Login to `wger` app and navigate to `exercises` in the menu bar then move your mouse over the body parts `tab`.
#### What are the relevant pivotal tracker stories?
[https://www.pivotaltracker.com/story/show/154239892](https://www.pivotaltracker.com/story/show/154239892)

#### Screenshots (if appropriate)
![demo](https://user-images.githubusercontent.com/15877982/35800827-30e53892-0a7b-11e8-9e2b-ccaa16b0765a.gif)

#### Questions:
None
