### PR TITLE
[ft #154239891] Show social login/register buttons

### DIFF
--- a/wger/core/templates/form.html
+++ b/wger/core/templates/form.html
@@ -30,23 +30,4 @@
         Side bar
 -->
 {% block sidebar %}
-<h3>Register with your Social Account</h3>
-    <hr/>
-    <a href="{% url "social:begin" 'facebook' %}"
-     class="btn btn-block btn-primary" >
-        <span class="fa fa-facebook"></span>  Register with Facebook
-    </a>
-    <a href="{% url "social:begin" 'twitter' %}"
-     class="btn btn-block btn-info">
-            <span class="fa fa-twitter"></span>  Register with Twitter
-        </a>
-        <a href="{% url "social:begin" 'github' %}" 
-        class="btn btn-block btn-default">
-                <span class="fa fa-github"></span>  Register with Github
-            </a>
-        </a>
-        <a href="{% url "social:begin" 'google-oauth2' %}" 
-        class="btn btn-block btn-danger">
-                <span class="fa fa-google"></span>  Login with Google
-            </a>
 {% endblock %}

--- a/wger/core/templates/user/login.html
+++ b/wger/core/templates/user/login.html
@@ -14,30 +14,30 @@
     {% trans 'Login' as submit_text %}
     {% render_form_fields form submit_text %}
 </form>
-<h3 style="margin-buttom:-4px" class="">Login with your Social Account</h3>
+<h3 style="margin-buttom:-4px" class=""> Login or Register using.</h3>
 <hr/>
 
 <button type="button" class="btn btn-outline-primary">
     <a href="{% url "social:begin" 'facebook' %}"
     class="btn btn-block btn-primary" >
-       <span class="fa fa-facebook"></span>  Login with Facebook
+       <span class="fa fa-facebook"></span>  Facebook
    </a></button>
 <button type="button" class="btn btn-outline-secondary">
     <a href="{% url "social:begin" 'twitter' %}"
     class="btn btn-block btn-info">
-           <span class="fa fa-twitter"></span>  Login with Twitter
+           <span class="fa fa-twitter"></span>  Twitter
        </a></button>
 
 <button type="button" class="btn btn-outline-success">
     <a href="{% url "social:begin" 'github' %}" 
     class="btn btn-block btn-default">
-            <span class="fa fa-github"></span>  Login with Github
+            <span class="fa fa-github"></span>  Github
         </a></button>
 
 <button type="button" class="btn btn-outline-success">
     <a href="{% url "socialgoogle:begin" 'google-oauth2' %}" 
     class="btn btn-block btn-danger">
-            <span class="fa fa-google"></span>  Login with Google
+            <span class="fa fa-google"></span>  Google
         </a></button>
         
 


### PR DESCRIPTION
#### What does this PR do?
This PR enables social logins with services like; Facebook, Twitter and Google
#### Description of Task to be completed?
- Currently a new user cannot login with their pre-existing social media account.
#### What are the relevant pivotal tracker stories?
[#154239890](https://www.pivotaltracker.com/story/show/154239891)
#### Screenshots (if appropriate)
Facebook Login Approval screenshot :- 
<img width="892" alt="screen shot 2018-01-25 at 11 01 03 am" src="https://user-images.githubusercontent.com/20403937/35391519-019b6c98-01f0-11e8-8e66-72b7311e7380.png">
Twitter Login Approval screenshot :- 
<img width="839" alt="screen shot 2018-01-25 at 11 01 25 am" src="https://user-images.githubusercontent.com/20403937/35391546-14b9a24a-01f0-11e8-9844-ff51a086a41e.png">
Github Login Approval screenshot :- 
<img width="855" alt="screen shot 2018-01-25 at 11 01 12 am" src="https://user-images.githubusercontent.com/20403937/35391573-296823e2-01f0-11e8-853d-353a42970669.png">
